### PR TITLE
Allow CFLAGS and CC to be append and set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CFLAGS = -g -Wall -I. -fPIC
-CC = gcc
+CFLAGS += -g -Wall -I. -fPIC
+CC ?= gcc
 PREFIX = $(DESTDIR)/usr/local
 TESTS = $(patsubst %.c, %, $(wildcard t/*.c))
 


### PR DESCRIPTION
This change would allow CFLAGS to be append in the command line - for example if we want to make 32bit version on 64bit file we can do:

CFLAGS=-m32 make

which is not possible if you use equals.

likewise ?= in CC allow user to set CC in the environment

Taken from advice here: http://stackoverflow.com/a/32696474/2817703
